### PR TITLE
Filter Duplicate shouldn't filter command results

### DIFF
--- a/src/org/traccar/FilterHandler.java
+++ b/src/org/traccar/FilterHandler.java
@@ -97,7 +97,8 @@ public class FilterHandler extends BaseDataHandler {
     }
 
     private boolean filterDuplicate(Position position, Position last) {
-        return filterDuplicate && last != null && position.getFixTime().equals(last.getFixTime());
+        return filterDuplicate && last != null && position.getFixTime().equals(last.getFixTime())
+            && position.getAttributes().get(Position.KEY_RESULT) == null;
     }
 
     private boolean filterFuture(Position position) {


### PR DESCRIPTION
Filter Duplicate filtered command results because their fixtime can be equal to the last one with position