### PR TITLE
Duplicate Filter filtered to much

### DIFF
--- a/src/org/traccar/FilterHandler.java
+++ b/src/org/traccar/FilterHandler.java
@@ -94,7 +94,8 @@ public class FilterHandler extends BaseDataHandler {
     }
 
     private boolean filterDuplicate(Position position, Position last) {
-        return filterDuplicate && last != null && position.getFixTime().equals(last.getFixTime());
+        return filterDuplicate && last != null && position.getFixTime().equals(last.getFixTime())
+            && position.getAttributes().equals(last.getAttributes());
     }
 
     private boolean filterFuture(Position position) {


### PR DESCRIPTION
For example commands may not have a new fix time and get filtered out if the duplicate filter only checks the FixTime. It should also check if the attributes differs, to prevent something like that.